### PR TITLE
Update debian/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ phdlogview (0.6.4) main; urgency=medium
 
   * New version release
 
- -- Andy Galasso <agalasso@bento.net>  Mon, 29 Dec 2025 19:36:25 -0500
+ -- Andy Galasso <andy.galasso@gmail.com>  Mon, 29 Dec 2025 19:36:25 -0500
 
 phdlogview (0.6.3) main; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,7 +8,7 @@ phdlogview (0.6.3) main; urgency=medium
 
   * New version release
 
- -- Andy Galasso <agalasso@bento.net>  Sun, 29 Aug 2021 05:01:49 -0500
+ -- Andy Galasso <andy.galasso@gmail.com>  Sun, 29 Aug 2021 05:01:49 -0500
 
 phdlogview (0.6.2) main; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,12 +1,17 @@
-phdlogview (0.6.3) buster; urgency=medium
+phdlogview (0.6.4) main; urgency=medium
 
-  * Upstream release
+  * New version release
 
- -- Radek Kaczorek <rkaczorek@gmail.com>  Sun, 29 Aug 2021 10:01:49 +0000
+ -- Andy Galasso <agalasso@bento.net>  Mon, 29 Dec 2025 19:36:25 -0500
 
-phdlogview (0.6.2) buster; urgency=medium
+phdlogview (0.6.3) main; urgency=medium
+
+  * New version release
+
+ -- Andy Galasso <agalasso@bento.net>  Sun, 29 Aug 2021 05:01:49 -0500
+
+phdlogview (0.6.2) main; urgency=medium
 
   * Initial release
 
- -- Radek Kaczorek <rkaczorek@gmail.com>  Sat, 19 Oct 2019 23:00:00 +0200
-
+ -- Andy Galasso <agalasso@bento.net>  Sat, 19 Oct 2019 16:00:00 -0500

--- a/debian/changelog
+++ b/debian/changelog
@@ -14,4 +14,4 @@ phdlogview (0.6.2) main; urgency=medium
 
   * Initial release
 
- -- Andy Galasso <agalasso@bento.net>  Sat, 19 Oct 2019 16:00:00 -0500
+ -- Andy Galasso <andy.galasso@gmail.com>  Sat, 19 Oct 2019 16:00:00 -0500


### PR DESCRIPTION
Hi @agalasso 
I have updated version in debian/changelog.
I'm afraid I forgot about it when asking for setting tag for 0.6.4. To fix it, just remove the existing tag 0.6.4 and set it again after merging this PR.
Thanks,
Radek
